### PR TITLE
update base calico image to v3.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/calico/cni:v3.22.0
+FROM quay.io/calico/cni:v3.24.1
 COPY artifacts/portmap /opt/cni/bin/portmap


### PR DESCRIPTION
Updating base image for k8s v1.25.2 (https://github.com/rancher/kontainer-driver-metadata/pull/991). Repo was originally added to replace portmap for https://github.com/rancher/rke/issues/2999 