### PR TITLE
update base calico image to v3.25.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -53,33 +53,6 @@ steps:
       event: tag
 ---
 kind: pipeline
-name: arm
-
-platform:
-  os: linux
-  arch: arm
-
-steps:
-  - name: download
-    image: alpine
-    commands:
-      - ./scripts/download-arm
-  - name: docker
-    image: plugins/docker
-    settings:
-      dockerfile: Dockerfile
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      repo: rancher/calico-cni
-      tag: ${DRONE_TAG}-linux-arm
-    when:
-      instance:
-        - drone-publish.rancher.io
-      event: tag
----
-kind: pipeline
 name: manifest
 
 steps:
@@ -100,4 +73,3 @@ steps:
 depends_on:
 - amd64
 - arm64
-- arm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/calico/cni:v3.24.1
+FROM quay.io/calico/cni:v3.25.0
 COPY artifacts/portmap /opt/cni/bin/portmap


### PR DESCRIPTION
- Updating to use v3.25.0 for k8s 1.26 https://github.com/rancher/rancher/issues/41113 
- Removed arm as we don't support it, hyperkube also builds for arm64 and amd64 only https://github.com/rancher/hyperkube/blob/v1.26.4-rancher2/.drone.yml#L108-L109 