### PR TITLE
[v1.28] Add calico v3.27.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/calico/cni:v3.26.3
+FROM quay.io/calico/cni:v3.27.0
 COPY artifacts/portmap /opt/cni/bin/portmap


### PR DESCRIPTION
### Update
* Add calico v3.27.0
* TODO: Create and change the base branch to `release-v3.27.0`

### Related
* https://github.com/rancher/rancher/issues/43109