### PR TITLE
[v1.29] Add calico v3.27.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/calico/cni:v3.28.0
+FROM quay.io/calico/cni:v3.27.4
 COPY artifacts/portmap /opt/cni/bin/portmap


### PR DESCRIPTION
### Update
* Add calico v3.27.4
* TODO: 
  * [ ] Create and change the base branch to `release-v3.27-rancher1`

### Related
* https://github.com/rancher/rke/issues/3648